### PR TITLE
rename why-do-this

### DIFF
--- a/_posts/2023-12-20-why-do-this.md
+++ b/_posts/2023-12-20-why-do-this.md
@@ -1,3 +1,10 @@
+---
+layout: post
+title:  "Why do this?"
+date:   2023-12-10 22:30:02 -0600
+categories: getting-started
+---
+
 # 12/9/23 Why do this 
 Why do I want to spend any amount of time on a computer writing down
 my thoughts to no one after I spend at least 40 hours per week looking 


### PR DESCRIPTION
a previous commit moved my first post `why-do-this` to the _posts directory. It was not properly named for jekyll to use though. It has been renamed so that jekyll recognizes it.